### PR TITLE
grammar: Fix built-in type list

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -461,20 +461,14 @@ module.exports = grammar({
     ),
 
     primitive_type: $ => token(choice(
-      'bool',
+      '_Bool',
+      '_Complex',
+      '_Imaginary',
       'char',
       'int',
       'float',
       'double',
       'void',
-      'size_t',
-      'ssize_t',
-      'intptr_t',
-      'uintptr_t',
-      'charptr_t',
-      ...[8, 16, 32, 64].map(n => `int${n}_t`),
-      ...[8, 16, 32, 64].map(n => `uint${n}_t`),
-      ...[8, 16, 32, 64].map(n => `char${n}_t`)
     )),
 
     enum_specifier: $ => seq(

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -218,6 +218,7 @@ Typedefs
 ============================================
 
 typedef int my_int;
+typedef _Complex size_t;
 
 typedef struct {
   int x;
@@ -232,6 +233,9 @@ typedef struct A {
 ---
 
 (translation_unit
+  (type_definition
+    type: (primitive_type)
+    declarator: (type_identifier))
   (type_definition
     type: (primitive_type)
     declarator: (type_identifier))
@@ -252,7 +256,7 @@ typedef struct A {
           type: (primitive_type)
           declarator: (abstract_pointer_declarator))
         (parameter_declaration
-          type: (primitive_type)))))
+          type: (type_identifier)))))
   (type_definition
     type: (struct_specifier
       name: (type_identifier)

--- a/test/corpus/preprocessor.txt
+++ b/test/corpus/preprocessor.txt
@@ -115,7 +115,7 @@ int b;
   (preproc_ifdef
     name: (identifier)
     (declaration
-      type: (primitive_type)
+      type: (type_identifier)
       declarator: (identifier))
     (preproc_def
       name: (identifier)
@@ -238,7 +238,7 @@ struct S {
     (preproc_ifdef (identifier)
       (field_declaration (type_identifier) (field_identifier))
       (preproc_else
-        (field_declaration (primitive_type) (field_identifier)))))))
+        (field_declaration (type_identifier) (field_identifier)))))))
 
 ====================================
 Unknown preprocessor directives
@@ -271,4 +271,4 @@ uint32_t a;
       (call_expression (identifier) (argument_list (binary_expression (identifier) (identifier))))
       (unary_expression
         (call_expression (identifier) (argument_list (identifier)))))
-    (declaration (primitive_type) (identifier))))
+    (declaration (type_identifier) (identifier))))

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -1,25 +1,14 @@
 ========================================
-Primitive types
+Built-in types
 ========================================
 
+_Bool a;
+_Complex a;
+_Imaginary a;
+char a;
 int a;
-uint8_t a;
-uint16_t a;
-uint32_t a;
-uint64_t a;
-uintptr_t a;
-
-int8_t a;
-int16_t a;
-int32_t a;
-int64_t a;
-intptr_t a;
-
-char16_t a;
-char32_t a;
-
-size_t a;
-ssize_t a;
+float a;
+double a;
 
 ---
 
@@ -30,15 +19,84 @@ ssize_t a;
   (declaration (primitive_type) (identifier))
   (declaration (primitive_type) (identifier))
   (declaration (primitive_type) (identifier))
-  (declaration (primitive_type) (identifier))
-  (declaration (primitive_type) (identifier))
-  (declaration (primitive_type) (identifier))
-  (declaration (primitive_type) (identifier))
-  (declaration (primitive_type) (identifier))
-  (declaration (primitive_type) (identifier))
-  (declaration (primitive_type) (identifier))
-  (declaration (primitive_type) (identifier))
   (declaration (primitive_type) (identifier)))
+
+========================================
+Non-built-in standard type definitions
+========================================
+
+// Common definitions
+ptrdiff_t a;
+size_t a;
+wchar_t a;
+
+// Integer types
+int8_t a;
+int16_t a;
+int32_t a;
+int64_t a;
+
+uint8_t a;
+uint16_t a;
+uint32_t a;
+uint64_t a;
+
+int_least8_t a;
+int_least16_t a;
+int_least32_t a;
+int_least64_t a;
+
+uint_least8_t a;
+uint_least16_t a;
+uint_least32_t a;
+uint_least64_t a;
+
+intptr_t a;
+uintptr_t a;
+
+intmax_t a;
+uintmax_t a;
+
+// C11
+char16_t a;
+char32_t a;
+
+// POSIX
+ssize_t a;
+
+---
+
+(translation_unit
+  (comment)
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (comment)
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (comment)
+  (declaration (type_identifier) (identifier))
+  (declaration (type_identifier) (identifier))
+  (comment)
+  (declaration (type_identifier) (identifier)))
 
 ========================================
 Type modifiers


### PR DESCRIPTION
Some of the types listed as “primitve types” are indeed primitive, but
not built-in as far as the language standard goes. Moreover, a few are
missing, so this commit removes the common definitions, such as
{u,}intN_t and friends and adds the fancy C99 _Bool, _Complex and
_Imaginary.

Since the change broke existing tests, this additionally updates the
corpus. New checks are added to see if the common type definitions are
not mistaken for built-in types.

The downside of this all would be that those common definitions cease to
be highlighted.

Closes https://github.com/tree-sitter/tree-sitter-c/issues/52