### PR TITLE
Allow $ (dollar sign) in identifiers

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6425,7 +6425,7 @@
     },
     "identifier": {
       "type": "PATTERN",
-      "value": "[a-zA-Z_]\\w*"
+      "value": "[a-zA-Z_$][\\w$]*"
     },
     "_type_identifier": {
       "type": "ALIAS",


### PR DESCRIPTION
Many common C compilers support `$` being a valid identifier character as a simple extension including GCC, Clang, and even MSVC.