### PR TITLE
Adds GH tag queries

### DIFF
--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -1,0 +1,9 @@
+(struct_specifier name: (type_identifier) @name body:(_)) @definition.class
+
+(declaration type: (union_specifier name: (type_identifier) @name)) @definition.class
+
+(function_declarator declarator: (identifier) @name) @definition.function
+
+(type_definition declarator: (type_identifier) @name) @definition.type
+
+(enum_specifier name: (type_identifier) @name) @definition.type


### PR DESCRIPTION
This PR adds new tags queries to `tags.scm` to support code search on Github.com.