### PR TITLE
Fix AppVeyor CI builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,7 @@
-image: Visual Studio 2015
+image: Visual Studio 2022
 
 environment:
-  nodejs_version: "8"
+  nodejs_version: "18"
 
 platform:
   - x64


### PR DESCRIPTION
Update used Windows image and NodeJS version to the latest LTS.

See:
- https://www.appveyor.com/docs/windows-images-software/#operating-system
- https://www.appveyor.com/docs/windows-images-software/#node-js
- https://endoflife.date/nodejs