### PR TITLE
Remove unused Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-
-sudo: false
-
-node_js: 10

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # tree-sitter-c
 
-[![Build Status](https://travis-ci.org/tree-sitter/tree-sitter-c.svg?branch=master)](https://travis-ci.org/tree-sitter/tree-sitter-c)
 [![Build status](https://ci.appveyor.com/api/projects/status/7u0sy6ajmxro4wfh/branch/master?svg=true)](https://ci.appveyor.com/project/maxbrunsfeld/tree-sitter-c/branch/master)
 
 C grammar for [tree-sitter](https://github.com/tree-sitter/tree-sitter).


### PR DESCRIPTION
It doesn't even build anymore there, and it's disabled anyway. Last edit was 4 years ago. Time to go.