### PR TITLE
ci: use nodejs 20 for appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,7 @@
 image: Visual Studio 2022
 
 environment:
-  nodejs_version: "18"
+  nodejs_version: "20"
 
 platform:
   - x64


### PR DESCRIPTION
It should fix the error since NodeJS 20.x versions are the new LTS: https://endoflife.date/nodejs