### PR TITLE
Support #if and #ifdef in if statements

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -152,6 +152,7 @@ module.exports = grammar({
     ...preprocIf('_in_field_declaration_list', $ => $._field_declaration_list_item),
     ...preprocIf('_in_enumerator_list', $ => seq($.enumerator, ',')),
     ...preprocIf('_in_enumerator_list_no_comma', $ => $.enumerator, -1),
+    ...preprocIf('_in_if_statement', $ => $._else_clause_or_preproc, -1),
 
     preproc_arg: _ => token(prec(-1, /\S([^/\n]|\/[^*]|\\\r?\n)*/)),
     preproc_directive: _ => /#[ \t]*[a-zA-Z0-9]\w*/,
@@ -824,10 +825,17 @@ module.exports = grammar({
       'if',
       field('condition', $.parenthesized_expression),
       field('consequence', $._statement),
-      optional(field('alternative', $.else_clause)),
+      optional(field('alternative', $._else_clause_or_preproc)),
     )),
 
+    _else_clause_or_preproc: $ => choice($.else_clause, $._else_clause_preproc),
+
     else_clause: $ => seq('else', $._statement),
+
+    _else_clause_preproc: $ => choice(
+      $.preproc_if_in_if_statement,
+      $.preproc_ifdef_in_if_statement,
+    ),
 
     switch_statement: $ => seq(
       'switch',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1853,6 +1853,371 @@
         ]
       }
     },
+    "preproc_if_in_if_statement": {
+      "type": "PREC",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "PATTERN",
+              "value": "#[ \t]*if"
+            },
+            "named": false,
+            "value": "#if"
+          },
+          {
+            "type": "FIELD",
+            "name": "condition",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_preproc_expression"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "\n"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_else_clause_or_preproc"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "alternative",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_else_in_if_statement"
+                      },
+                      "named": true,
+                      "value": "preproc_else"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elif_in_if_statement"
+                      },
+                      "named": true,
+                      "value": "preproc_elif"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "PATTERN",
+              "value": "#[ \t]*endif"
+            },
+            "named": false,
+            "value": "#endif"
+          }
+        ]
+      }
+    },
+    "preproc_ifdef_in_if_statement": {
+      "type": "PREC",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "#[ \t]*ifdef"
+                },
+                "named": false,
+                "value": "#ifdef"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "#[ \t]*ifndef"
+                },
+                "named": false,
+                "value": "#ifndef"
+              }
+            ]
+          },
+          {
+            "type": "FIELD",
+            "name": "name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "identifier"
+            }
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_else_clause_or_preproc"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "alternative",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "preproc_else_in_if_statement"
+                          },
+                          "named": true,
+                          "value": "preproc_else"
+                        },
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "preproc_elif_in_if_statement"
+                          },
+                          "named": true,
+                          "value": "preproc_elif"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elifdef_in_if_statement"
+                      },
+                      "named": true,
+                      "value": "preproc_elifdef"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "PATTERN",
+              "value": "#[ \t]*endif"
+            },
+            "named": false,
+            "value": "#endif"
+          }
+        ]
+      }
+    },
+    "preproc_else_in_if_statement": {
+      "type": "PREC",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "PATTERN",
+              "value": "#[ \t]*else"
+            },
+            "named": false,
+            "value": "#else"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_else_clause_or_preproc"
+            }
+          }
+        ]
+      }
+    },
+    "preproc_elif_in_if_statement": {
+      "type": "PREC",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "PATTERN",
+              "value": "#[ \t]*elif"
+            },
+            "named": false,
+            "value": "#elif"
+          },
+          {
+            "type": "FIELD",
+            "name": "condition",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_preproc_expression"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "\n"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_else_clause_or_preproc"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "alternative",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_else_in_if_statement"
+                      },
+                      "named": true,
+                      "value": "preproc_else"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elif_in_if_statement"
+                      },
+                      "named": true,
+                      "value": "preproc_elif"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "preproc_elifdef_in_if_statement": {
+      "type": "PREC",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "#[ \t]*elifdef"
+                },
+                "named": false,
+                "value": "#elifdef"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "#[ \t]*elifndef"
+                },
+                "named": false,
+                "value": "#elifndef"
+              }
+            ]
+          },
+          {
+            "type": "FIELD",
+            "name": "name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "identifier"
+            }
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_else_clause_or_preproc"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "alternative",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_else_in_if_statement"
+                      },
+                      "named": true,
+                      "value": "preproc_else"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elif_in_if_statement"
+                      },
+                      "named": true,
+                      "value": "preproc_elif"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
     "preproc_arg": {
       "type": "TOKEN",
       "content": {
@@ -5883,7 +6248,7 @@
                 "name": "alternative",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "else_clause"
+                  "name": "_else_clause_or_preproc"
                 }
               },
               {
@@ -5893,6 +6258,19 @@
           }
         ]
       }
+    },
+    "_else_clause_or_preproc": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "else_clause"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_else_clause_preproc"
+        }
+      ]
     },
     "else_clause": {
       "type": "SEQ",
@@ -5904,6 +6282,19 @@
         {
           "type": "SYMBOL",
           "name": "_statement"
+        }
+      ]
+    },
+    "_else_clause_preproc": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "preproc_if_in_if_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "preproc_ifdef_in_if_statement"
         }
       ]
     },
@@ -9522,5 +9913,29 @@
     "_field_declarator",
     "_type_declarator",
     "_abstract_declarator"
-  ]
+  ],
+  "PREC": {
+    "PAREN_DECLARATOR": -10,
+    "ASSIGNMENT": -2,
+    "CONDITIONAL": -1,
+    "DEFAULT": 0,
+    "LOGICAL_OR": 1,
+    "LOGICAL_AND": 2,
+    "INCLUSIVE_OR": 3,
+    "EXCLUSIVE_OR": 4,
+    "BITWISE_AND": 5,
+    "EQUAL": 6,
+    "RELATIONAL": 7,
+    "OFFSETOF": 8,
+    "SHIFT": 9,
+    "ADD": 10,
+    "MULTIPLY": 11,
+    "CAST": 12,
+    "SIZEOF": 13,
+    "UNARY": 14,
+    "CALL": 15,
+    "FIELD": 16,
+    "SUBSCRIPT": 17
+  }
 }
+

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2104,6 +2104,14 @@
           {
             "type": "else_clause",
             "named": true
+          },
+          {
+            "type": "preproc_if_in_if_statement",
+            "named": true
+          },
+          {
+            "type": "preproc_ifdef_in_if_statement",
+            "named": true
           }
         ]
       },
@@ -2750,6 +2758,10 @@
           "named": true
         },
         {
+          "type": "else_clause",
+          "named": true
+        },
+        {
           "type": "enumerator",
           "named": true
         },
@@ -2782,7 +2794,15 @@
           "named": true
         },
         {
+          "type": "preproc_if_in_if_statement",
+          "named": true
+        },
+        {
           "type": "preproc_ifdef",
+          "named": true
+        },
+        {
+          "type": "preproc_ifdef_in_if_statement",
           "named": true
         },
         {
@@ -2842,6 +2862,10 @@
           "named": true
         },
         {
+          "type": "else_clause",
+          "named": true
+        },
+        {
           "type": "enumerator",
           "named": true
         },
@@ -2874,7 +2898,15 @@
           "named": true
         },
         {
+          "type": "preproc_if_in_if_statement",
+          "named": true
+        },
+        {
           "type": "preproc_ifdef",
+          "named": true
+        },
+        {
+          "type": "preproc_ifdef_in_if_statement",
           "named": true
         },
         {
@@ -2909,6 +2941,10 @@
           "named": true
         },
         {
+          "type": "else_clause",
+          "named": true
+        },
+        {
           "type": "enumerator",
           "named": true
         },
@@ -2941,7 +2977,15 @@
           "named": true
         },
         {
+          "type": "preproc_if_in_if_statement",
+          "named": true
+        },
+        {
           "type": "preproc_ifdef",
+          "named": true
+        },
+        {
+          "type": "preproc_ifdef_in_if_statement",
           "named": true
         },
         {
@@ -3112,6 +3156,82 @@
     }
   },
   {
+    "type": "preproc_if_in_if_statement",
+    "named": true,
+    "fields": {
+      "alternative": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "preproc_elif",
+            "named": true
+          },
+          {
+            "type": "preproc_else",
+            "named": true
+          }
+        ]
+      },
+      "condition": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "binary_expression",
+            "named": true
+          },
+          {
+            "type": "call_expression",
+            "named": true
+          },
+          {
+            "type": "char_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "number_literal",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
+            "type": "preproc_defined",
+            "named": true
+          },
+          {
+            "type": "unary_expression",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "else_clause",
+          "named": true
+        },
+        {
+          "type": "preproc_if_in_if_statement",
+          "named": true
+        },
+        {
+          "type": "preproc_ifdef_in_if_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "preproc_ifdef",
     "named": true,
     "fields": {
@@ -3202,6 +3322,58 @@
         },
         {
           "type": "type_definition",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "preproc_ifdef_in_if_statement",
+    "named": true,
+    "fields": {
+      "alternative": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "preproc_elif",
+            "named": true
+          },
+          {
+            "type": "preproc_elifdef",
+            "named": true
+          },
+          {
+            "type": "preproc_else",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "else_clause",
+          "named": true
+        },
+        {
+          "type": "preproc_if_in_if_statement",
+          "named": true
+        },
+        {
+          "type": "preproc_ifdef_in_if_statement",
           "named": true
         }
       ]

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,8 +13,9 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSStateId;
+
+#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -129,16 +130,9 @@ struct TSLanguage {
  *  Lexer Macros
  */
 
-#ifdef _MSC_VER
-#define UNUSED __pragma(warning(suppress : 4101))
-#else
-#define UNUSED __attribute__((unused))
-#endif
-
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
-  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -172,7 +166,7 @@ struct TSLanguage {
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+#define SMALL_STATE(id) id - LARGE_STATE_COUNT
 
 #define STATE(id) id
 
@@ -182,7 +176,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value)          \
+      .state = state_value            \
     }                                 \
   }}
 
@@ -190,7 +184,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value),         \
+      .state = state_value,           \
       .repetition = true              \
     }                                 \
   }}

--- a/test/corpus/preprocessor.txt
+++ b/test/corpus/preprocessor.txt
@@ -399,3 +399,86 @@ uint32_t a;
     (declaration
       (primitive_type)
       (identifier))))
+
+
+================================================================================
+Preprocessor between if and else
+================================================================================
+
+if (condition)
+{
+   result = fun();
+}
+#ifdef SOMETHING
+else
+{
+   result = fun();
+}
+#endif
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+ (if_statement
+  condition: (parenthesized_expression
+     (identifier))
+  consequence: (compound_statement
+     (expression_statement
+      (assignment_expression
+       left: (identifier)
+       right: (call_expression
+          function: (identifier)
+          arguments: (argument_list)))))
+  alternative: (preproc_ifdef_in_if_statement
+     name: (identifier)
+     (else_clause
+      (compound_statement
+       (expression_statement
+        (assignment_expression
+         left: (identifier)
+         right: (call_expression
+            function: (identifier)
+            arguments: (argument_list)))))))))
+
+================================================================================
+Two preprocessor between if and else
+================================================================================
+
+if (condition)
+{
+   result = fun();
+}
+#if SOMETHING
+#ifndef SOMETHING_ELSE
+else
+{
+   result = fun();
+}
+#endif
+#endif
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+ (if_statement
+  condition: (parenthesized_expression
+     (identifier))
+  consequence: (compound_statement
+     (expression_statement
+      (assignment_expression
+       left: (identifier)
+       right: (call_expression
+          function: (identifier)
+          arguments: (argument_list)))))
+  alternative: (preproc_if_in_if_statement
+     condition: (identifier)
+     (preproc_ifdef_in_if_statement
+      name: (identifier)
+      (else_clause
+       (compound_statement
+        (expression_statement
+         (assignment_expression
+          left: (identifier)
+          right: (call_expression
+             function: (identifier)
+             arguments: (argument_list))))))))))


### PR DESCRIPTION
Fixes #76 

I was not able to add more than `$.preproc_if_in_if_statement` and `$.preproc_ifdef_in_if_statement` to `_else_clause_preproc`. I got some conflicts. I am not very experienced in writing tree-sitter grammars.