### PR TITLE
Fix preproc alternatives (elif, elifdef, else)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1375,22 +1375,12 @@ function preprocIf(suffix, content, precedence = 0) {
     * @return {ChoiceRule}
     *
     */
-  function elseBlock($) {
+  function alternativeBlock($) {
     return choice(
       suffix ? alias($['preproc_else' + suffix], $.preproc_else) : $.preproc_else,
       suffix ? alias($['preproc_elif' + suffix], $.preproc_elif) : $.preproc_elif,
+      suffix ? alias($['preproc_elifdef' + suffix], $.preproc_elifdef) : $.preproc_elifdef,
     );
-  }
-
-  /**
-    *
-    * @param {GrammarSymbols<string>} $
-    *
-    * @return {AliasRule | SymbolRule<string>}
-    *
-    */
-  function elifBlock($) {
-    return suffix ? alias($['preproc_elifdef' + suffix], $.preproc_elifdef) : $.preproc_elifdef;
   }
 
   return {
@@ -1399,7 +1389,7 @@ function preprocIf(suffix, content, precedence = 0) {
       field('condition', $._preproc_expression),
       '\n',
       repeat(content($)),
-      field('alternative', optional(elseBlock($))),
+      field('alternative', optional(alternativeBlock($))),
       preprocessor('endif'),
     )),
 
@@ -1407,7 +1397,7 @@ function preprocIf(suffix, content, precedence = 0) {
       choice(preprocessor('ifdef'), preprocessor('ifndef')),
       field('name', $.identifier),
       repeat(content($)),
-      field('alternative', optional(choice(elseBlock($), elifBlock($)))),
+      field('alternative', optional(alternativeBlock($))),
       preprocessor('endif'),
     )),
 
@@ -1421,14 +1411,14 @@ function preprocIf(suffix, content, precedence = 0) {
       field('condition', $._preproc_expression),
       '\n',
       repeat(content($)),
-      field('alternative', optional(elseBlock($))),
+      field('alternative', optional(alternativeBlock($))),
     )),
 
     ['preproc_elifdef' + suffix]: $ => prec(precedence, seq(
       choice(preprocessor('elifdef'), preprocessor('elifndef')),
       field('name', $.identifier),
       repeat(content($)),
-      field('alternative', optional(elseBlock($))),
+      field('alternative', optional(alternativeBlock($))),
     )),
   };
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -443,6 +443,10 @@
                     {
                       "type": "SYMBOL",
                       "name": "preproc_elif"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "preproc_elifdef"
                     }
                   ]
                 },
@@ -518,17 +522,12 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "preproc_else"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "preproc_elif"
-                        }
-                      ]
+                      "type": "SYMBOL",
+                      "name": "preproc_else"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "preproc_elif"
                     },
                     {
                       "type": "SYMBOL",
@@ -629,6 +628,10 @@
                     {
                       "type": "SYMBOL",
                       "name": "preproc_elif"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "preproc_elifdef"
                     }
                   ]
                 },
@@ -701,6 +704,10 @@
                     {
                       "type": "SYMBOL",
                       "name": "preproc_elif"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "preproc_elifdef"
                     }
                   ]
                 },
@@ -773,6 +780,15 @@
                       },
                       "named": true,
                       "value": "preproc_elif"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elifdef_in_field_declaration_list"
+                      },
+                      "named": true,
+                      "value": "preproc_elifdef"
                     }
                   ]
                 },
@@ -848,27 +864,22 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "ALIAS",
-                          "content": {
-                            "type": "SYMBOL",
-                            "name": "preproc_else_in_field_declaration_list"
-                          },
-                          "named": true,
-                          "value": "preproc_else"
-                        },
-                        {
-                          "type": "ALIAS",
-                          "content": {
-                            "type": "SYMBOL",
-                            "name": "preproc_elif_in_field_declaration_list"
-                          },
-                          "named": true,
-                          "value": "preproc_elif"
-                        }
-                      ]
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_else_in_field_declaration_list"
+                      },
+                      "named": true,
+                      "value": "preproc_else"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elif_in_field_declaration_list"
+                      },
+                      "named": true,
+                      "value": "preproc_elif"
                     },
                     {
                       "type": "ALIAS",
@@ -984,6 +995,15 @@
                       },
                       "named": true,
                       "value": "preproc_elif"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elifdef_in_field_declaration_list"
+                      },
+                      "named": true,
+                      "value": "preproc_elifdef"
                     }
                   ]
                 },
@@ -1066,6 +1086,15 @@
                       },
                       "named": true,
                       "value": "preproc_elif"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elifdef_in_field_declaration_list"
+                      },
+                      "named": true,
+                      "value": "preproc_elifdef"
                     }
                   ]
                 },
@@ -1147,6 +1176,15 @@
                       },
                       "named": true,
                       "value": "preproc_elif"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elifdef_in_enumerator_list"
+                      },
+                      "named": true,
+                      "value": "preproc_elifdef"
                     }
                   ]
                 },
@@ -1231,27 +1269,22 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "ALIAS",
-                          "content": {
-                            "type": "SYMBOL",
-                            "name": "preproc_else_in_enumerator_list"
-                          },
-                          "named": true,
-                          "value": "preproc_else"
-                        },
-                        {
-                          "type": "ALIAS",
-                          "content": {
-                            "type": "SYMBOL",
-                            "name": "preproc_elif_in_enumerator_list"
-                          },
-                          "named": true,
-                          "value": "preproc_elif"
-                        }
-                      ]
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_else_in_enumerator_list"
+                      },
+                      "named": true,
+                      "value": "preproc_else"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elif_in_enumerator_list"
+                      },
+                      "named": true,
+                      "value": "preproc_elif"
                     },
                     {
                       "type": "ALIAS",
@@ -1385,6 +1418,15 @@
                       },
                       "named": true,
                       "value": "preproc_elif"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elifdef_in_enumerator_list"
+                      },
+                      "named": true,
+                      "value": "preproc_elifdef"
                     }
                   ]
                 },
@@ -1476,6 +1518,15 @@
                       },
                       "named": true,
                       "value": "preproc_elif"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elifdef_in_enumerator_list"
+                      },
+                      "named": true,
+                      "value": "preproc_elifdef"
                     }
                   ]
                 },
@@ -1548,6 +1599,15 @@
                       },
                       "named": true,
                       "value": "preproc_elif"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elifdef_in_enumerator_list_no_comma"
+                      },
+                      "named": true,
+                      "value": "preproc_elifdef"
                     }
                   ]
                 },
@@ -1623,27 +1683,22 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "ALIAS",
-                          "content": {
-                            "type": "SYMBOL",
-                            "name": "preproc_else_in_enumerator_list_no_comma"
-                          },
-                          "named": true,
-                          "value": "preproc_else"
-                        },
-                        {
-                          "type": "ALIAS",
-                          "content": {
-                            "type": "SYMBOL",
-                            "name": "preproc_elif_in_enumerator_list_no_comma"
-                          },
-                          "named": true,
-                          "value": "preproc_elif"
-                        }
-                      ]
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_else_in_enumerator_list_no_comma"
+                      },
+                      "named": true,
+                      "value": "preproc_else"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elif_in_enumerator_list_no_comma"
+                      },
+                      "named": true,
+                      "value": "preproc_elif"
                     },
                     {
                       "type": "ALIAS",
@@ -1759,6 +1814,15 @@
                       },
                       "named": true,
                       "value": "preproc_elif"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elifdef_in_enumerator_list_no_comma"
+                      },
+                      "named": true,
+                      "value": "preproc_elifdef"
                     }
                   ]
                 },
@@ -1841,6 +1905,15 @@
                       },
                       "named": true,
                       "value": "preproc_elif"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elifdef_in_enumerator_list_no_comma"
+                      },
+                      "named": true,
+                      "value": "preproc_elifdef"
                     }
                   ]
                 },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2689,6 +2689,10 @@
             "named": true
           },
           {
+            "type": "preproc_elifdef",
+            "named": true
+          },
+          {
             "type": "preproc_else",
             "named": true
           }
@@ -2806,6 +2810,10 @@
         "types": [
           {
             "type": "preproc_elif",
+            "named": true
+          },
+          {
+            "type": "preproc_elifdef",
             "named": true
           },
           {
@@ -3001,6 +3009,10 @@
         "types": [
           {
             "type": "preproc_elif",
+            "named": true
+          },
+          {
+            "type": "preproc_elifdef",
             "named": true
           },
           {

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -66,9 +66,12 @@ extern "C" {
 /// Increase the array's size by `count` elements.
 /// New elements are zero-initialized.
 #define array_grow_by(self, count) \
-  (_array__grow((Array *)(self), count, array_elem_size(self)), \
-   memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)), \
-   (self)->size += (count))
+  do { \
+    if ((count) == 0) break; \
+    _array__grow((Array *)(self), count, array_elem_size(self)); \
+    memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
+    (self)->size += (count); \
+  } while (0)
 
 /// Append all elements from one array to the end of another.
 #define array_push_all(self, other)                                       \

--- a/test/corpus/preprocessor.txt
+++ b/test/corpus/preprocessor.txt
@@ -226,6 +226,54 @@ int b;
           (identifier))))))
 
 ================================================================================
+Mixing #elif and #elifdef
+================================================================================
+
+#ifndef DEFINE1
+int i;
+#elif  defined(DEFINE2)
+int j;
+#endif
+
+#if defined DEFINE3
+int a;
+#elifdef DEFINE4
+int b;
+#else
+int c;
+#endif
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (preproc_ifdef
+    name: (identifier)
+    (declaration
+      type: (primitive_type)
+      declarator: (identifier))
+    alternative: (preproc_elif
+      condition: (preproc_defined
+        (identifier))
+      (declaration
+        type: (primitive_type)
+        declarator: (identifier))))
+  (preproc_if
+    condition: (preproc_defined
+      (identifier))
+    (declaration
+      type: (primitive_type)
+      declarator: (identifier))
+    alternative: (preproc_elifdef
+      name: (identifier)
+      (declaration
+        type: (primitive_type)
+        declarator: (identifier))
+      alternative: (preproc_else
+        (declaration
+          type: (primitive_type)
+          declarator: (identifier))))))
+
+================================================================================
 General if blocks
 ================================================================================
 


### PR DESCRIPTION
Currently, there are two functions ("elseBlock" and "elifBlock") that are used to generate alternatives (i.e. "#elif", "#elifdef", "#else").
More precisely, "elseBlock" generates "#else" and "#elif" nodes, and elifBlock generates "#elifdef" nodes.

The "#ifdef" is currently the only node offering a choice between elseBlock and elifBlock. Other conditional directives only allow elseBlock and thus do not offer the possiblity to have (for example) a "#if" followed by a "#elifdef".

Concretely, consider the following code:

```
#if defined(FOO)
#elifdef BAR
#endif
```

This is currently parsed as a preproc_call


  ```
(translation_unit [0, 0] - [3, 0]
  (preproc_if [0, 0] - [2, 6]
    condition: (preproc_defined [0, 4] - [0, 16]
      (identifier [0, 12] - [0, 15]))
    (preproc_call [1, 0] - [2, 0]
      directive: (preproc_directive [1, 0] - [1, 8])
      argument: (preproc_arg [1, 9] - [1, 12]))))
```
I can't think about any reason to disallow this behavior so I suggest to merge both function into a single one that generate all possible alternatives.
For the given example, this would result in

```
(translation_unit [0, 0] - [3, 0]
  (preproc_if [0, 0] - [2, 6]
    condition: (preproc_defined [0, 4] - [0, 16]
      (identifier [0, 12] - [0, 15]))
    alternative: (preproc_elifdef [1, 0] - [1, 12]
      name: (identifier [1, 9] - [1, 12]))))
```

This commit also adds a test to check for regression
