### PR TITLE
feat: add Zig bindings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -35,3 +35,7 @@ go.sum linguist-generated
 bindings/swift/** linguist-generated
 Package.swift linguist-generated
 Package.resolved linguist-generated
+
+# Zig bindings
+build.zig linguist-generated
+build.zig.zon linguist-generated

--- a/bindings/zig/root.zig
+++ b/bindings/zig/root.zig
@@ -1,0 +1,19 @@
+const testing = @import("std").testing;
+
+const ts = @import("tree-sitter");
+const Language = ts.Language;
+const Parser = ts.Parser;
+
+pub extern fn tree_sitter_c() callconv(.C) *const Language;
+
+pub export fn language() *const Language {
+    return tree_sitter_c();
+}
+
+test "can load grammar" {
+    const parser = Parser.create();
+    defer parser.destroy();
+    try testing.expectEqual(parser.setLanguage(language()), void{});
+    try testing.expectEqual(parser.getLanguage(), tree_sitter_c());
+}
+

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,79 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const shared = b.option(bool, "build-shared", "Build a shared library") orelse true;
+    const reuse_alloc = b.option(bool, "reuse-allocator", "Reuse the library allocator") orelse false;
+
+    const lib: *std.Build.Step.Compile = if (shared) b.addSharedLibrary(.{
+        .name = "tree-sitter-c",
+        .pic = true,
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    }) else b.addStaticLibrary(.{
+        .name = "tree-sitter-c",
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+
+    lib.addCSourceFile(.{
+        .file = b.path("src/parser.c"),
+        .flags = &.{"-std=c11"},
+    });
+    if (hasScanner(b.build_root.handle)) {
+        lib.addCSourceFile(.{
+            .file = b.path("src/scanner.c"),
+            .flags = &.{"-std=c11"},
+        });
+    }
+
+    if (reuse_alloc) {
+        lib.root_module.addCMacro("TREE_SITTER_REUSE_ALLOCATOR", "");
+    }
+    if (optimize == .Debug) {
+        lib.root_module.addCMacro("TREE_SITTER_DEBUG", "");
+    }
+
+    lib.addIncludePath(b.path("src"));
+
+    b.installArtifact(lib);
+    b.installFile("src/node-types.json", "node-types.json");
+    b.installDirectory(.{ .source_dir = b.path("queries"), .install_dir = .prefix, .install_subdir = "queries", .include_extensions = &.{"scm"} });
+
+    const module = b.addModule("tree-sitter-c", .{
+        .root_source_file = b.path("bindings/zig/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    module.linkLibrary(lib);
+
+    const ts_dep = b.dependency("tree-sitter", .{});
+    const ts_mod = ts_dep.module("tree-sitter");
+    module.addImport("tree-sitter", ts_mod);
+
+    // ╭─────────────────╮
+    // │      Tests      │
+    // ╰─────────────────╯
+
+    const tests = b.addTest(.{
+        .root_source_file = b.path("bindings/zig/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    tests.linkLibrary(lib);
+    tests.root_module.addImport("tree-sitter", ts_mod);
+
+    const run_tests = b.addRunArtifact(tests);
+
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_tests.step);
+}
+
+inline fn hasScanner(dir: std.fs.Dir) bool {
+    dir.access("src/scanner.c", .{}) catch return false;
+    return true;
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,17 @@
+.{
+    .name = "tree-sitter-c",
+    .version = "0.23.4",
+    .dependencies = .{ .@"tree-sitter" = .{
+        .url = "https://github.com/tree-sitter/zig-tree-sitter/archive/refs/tags/v0.25.0.tar.gz",
+        .hash = "12201a8d5e840678bbbf5128e605519c4024af422295d68e2ba2090e675328e5811d",
+    } },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "bindings/zig",
+        "src",
+        "queries",
+        "LICENSE",
+        "README.md",
+    },
+}

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -38,6 +38,7 @@
     "node": true,
     "python": true,
     "rust": true,
-    "swift": true
+    "swift": true,
+    "zig": true
   }
 }


### PR DESCRIPTION
These are somewhat experimental, but are stable with the 0.25 release. However, we're holding off on immediately updating other generated files & bindings with 0.25 so that downstream can update to support ABI 15 parsers.

Also, the C grammar is being used in `zig-tree-sitter`'s tests, so this'll be the first grammar to introduce the bindings.