### PR TITLE
Highlight `_Generic` as a keyword

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -3,6 +3,7 @@
 ((identifier) @constant
  (#match? @constant "^[A-Z][A-Z\\d_]*$"))
 
+"_Generic" @keyword
 "break" @keyword
 "case" @keyword
 "const" @keyword


### PR DESCRIPTION
`tree-sitter-c` can parse `_Generic` selections, but the `_Generic` keyword is currently not highlighted at all.