### PR TITLE
Fix Swift Bindings

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,20 @@
     "pins": [
       {
         "package": "SwiftTreeSitter",
-        "repositoryURL": "https://github.com/ChimeHQ/SwiftTreeSitter",
+        "repositoryURL": "https://github.com/tree-sitter/swift-tree-sitter",
         "state": {
           "branch": null,
-          "revision": "2599e95310b3159641469d8a21baf2d3d200e61f",
-          "version": "0.8.0"
+          "revision": "08ef81eb8620617b55b08868126707ad72bf754f",
+          "version": "0.25.0"
+        }
+      },
+      {
+        "package": "TreeSitter",
+        "repositoryURL": "https://github.com/tree-sitter/tree-sitter",
+        "state": {
+          "branch": null,
+          "revision": "bf655c0beaf4943573543fa77c58e8006ff34971",
+          "version": "0.25.6"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .library(name: "TreeSitterC", targets: ["TreeSitterC"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tree-sitter/swift-tree-sitter", from: "0.8.0"),
+        .package(url: "https://github.com/tree-sitter/swift-tree-sitter", from: "0.9.0"),
     ],
     targets: [
         .target(
@@ -26,7 +26,7 @@ let package = Package(
         .testTarget(
             name: "TreeSitterCTests",
             dependencies: [
-                "SwiftTreeSitter",
+                .product(name: "SwiftTreeSitter", package: "swift-tree-sitter"),
                 "TreeSitterC",
             ],
             path: "bindings/swift/TreeSitterCTests"


### PR DESCRIPTION
The Swift bindings were not updated correctly and fail to resolve this package when using Swift 6. This fixes that, and updates the `swift-tree-sitter` dependency to the latest version.