### PR TITLE
feat: Support building Rust package for WASM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,12 @@ jobs:
         uses: tree-sitter/parse-action@v4
         with:
           files: examples/*
+  build-wasm:
+    name: Build for WASM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          target: wasm32-unknown-unknown
+      - run: cargo build --target=wasm32-unknown-unknown

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -4,6 +4,12 @@ fn main() {
     let mut c_config = cc::Build::new();
     c_config.std("c11").include(src_dir);
 
+    // Set a minimal C sysroot if building for wasm32-unknown-unknown.
+    if std::env::var("TARGET").unwrap() == "wasm32-unknown-unknown" {
+        let sysroot_dir = std::path::Path::new("bindings/rust/wasm-sysroot");
+        c_config.include(sysroot_dir);
+    }
+
     #[cfg(target_env = "msvc")]
     c_config.flag("-utf-8");
 

--- a/bindings/rust/wasm-sysroot/stdint.h
+++ b/bindings/rust/wasm-sysroot/stdint.h
@@ -1,0 +1,19 @@
+#pragma once
+
+typedef signed char int8_t;
+typedef short int16_t;
+typedef long int32_t;
+typedef long long int64_t;
+
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned long uint32_t;
+typedef unsigned long long uint64_t;
+
+typedef unsigned long size_t;
+
+typedef unsigned int uintptr_t;
+
+#define UINT8_MAX 0xff
+#define UINT16_MAX 0xffff
+#define UINT32_MAX 0xffffffff

--- a/bindings/rust/wasm-sysroot/stdlib.h
+++ b/bindings/rust/wasm-sysroot/stdlib.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <stdint.h>
+
+#define NULL ((void*)0)
+
+void* malloc(size_t size);
+void* calloc(size_t nmemb, size_t size);
+void free(void* ptr);
+void* realloc(void* ptr, size_t size);
+
+void abort(void);


### PR DESCRIPTION
Tree-sitter claims to support building for WebAssembly and yet on every step of the way there are road blocks if you want something more than download a pre-built WASM binary blob. That people struggle with it is obvious from the various discussions surrounding the matter, e.g.:
- https://github.com/tree-sitter/tree-sitter/discussions/1550
- https://github.com/tree-sitter/tree-sitter/discussions/2010
- https://github.com/tree-sitter/tree-sitter/discussions/1024

It's not just the core library: even languages fail to build for the target (certainly their Rust bindings). Turns out it's actually not that hard to get going and this change boils down the various recommendations from some of the discussions into making this package build for the `wasm32-unknown-unknown` target out of the box. All that has to be done is to add and make known a minimal sysroot with header files that make certain types known and stub out core C allocation functions.