### PR TITLE
fix: correctly parse preprocessor token pasting and stringification

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -51,11 +51,13 @@
 "==" @operator
 ">" @operator
 "||" @operator
+"##" @operator
 
 "." @delimiter
 ";" @delimiter
 
 (string_literal) @string
+(stringification) @keyword
 (system_lib_string) @string
 
 (null) @constant

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json",
   "name": "c",
-  "word": "identifier",
+  "word": "_preproc_token",
   "rules": {
     "translation_unit": {
       "type": "REPEAT",
@@ -1933,8 +1933,46 @@
         "type": "PREC",
         "value": -1,
         "content": {
-          "type": "PATTERN",
-          "value": "\\S([^/\\n]|\\/[^*]|\\\\\\r?\\n)*"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "PATTERN",
+              "value": "\\S([^/\\n]|\\/[^*]|\\\\\\r?\\n)*"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "/*"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "[^*]*\\*+([^/*][^*]*\\*+)*"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "/"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "([ \t]|\\\\\\r?\\n)*"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "\\S([^/\\n]|\\/[^*]|\\\\\\r?\\n)*"
+                  }
+                ]
+              }
+            }
+          ]
         }
       }
     },
@@ -9339,66 +9377,79 @@
       }
     },
     "string_literal": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "CHOICE",
+          "type": "SYMBOL",
+          "name": "stringification"
+        },
+        {
+          "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "L\""
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "L\""
+                },
+                {
+                  "type": "STRING",
+                  "value": "u\""
+                },
+                {
+                  "type": "STRING",
+                  "value": "U\""
+                },
+                {
+                  "type": "STRING",
+                  "value": "u8\""
+                },
+                {
+                  "type": "STRING",
+                  "value": "\""
+                }
+              ]
             },
             {
-              "type": "STRING",
-              "value": "u\""
-            },
-            {
-              "type": "STRING",
-              "value": "U\""
-            },
-            {
-              "type": "STRING",
-              "value": "u8\""
+              "type": "REPEAT",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "IMMEDIATE_TOKEN",
+                      "content": {
+                        "type": "PREC",
+                        "value": 1,
+                        "content": {
+                          "type": "PATTERN",
+                          "value": "[^\\\\\"\\n]+"
+                        }
+                      }
+                    },
+                    "named": true,
+                    "value": "string_content"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "escape_sequence"
+                  }
+                ]
+              }
             },
             {
               "type": "STRING",
               "value": "\""
             }
           ]
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "IMMEDIATE_TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 1,
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[^\\\\\"\\n]+"
-                    }
-                  }
-                },
-                "named": true,
-                "value": "string_content"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "escape_sequence"
-              }
-            ]
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "\""
         }
       ]
+    },
+    "stringification": {
+      "type": "PATTERN",
+      "value": "#[_a-zA-Z]\\w*"
     },
     "escape_sequence": {
       "type": "TOKEN",
@@ -9518,9 +9569,24 @@
         }
       ]
     },
-    "identifier": {
+    "_preproc_token": {
       "type": "PATTERN",
       "value": "(\\p{XID_Start}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\\\U[0-9A-Fa-f]{8})(\\p{XID_Continue}|\\$|\\\\u[0-9A-Fa-f]{4}|\\\\U[0-9A-Fa-f]{8})*"
+    },
+    "identifier": {
+      "type": "SEQ",
+      "members": [
+        { "type": "SYMBOL", "name": "_preproc_token" },
+        {
+          "type": "REPEAT", "content": {
+            "type": "SEQ",
+            "members": [
+              { "type": "STRING", "value": "##" },
+              { "type": "SYMBOL", "name": "_preproc_token" }
+            ]
+          }
+        }
+      ]
     },
     "_type_identifier": {
       "type": "ALIAS",


### PR DESCRIPTION
Code snippet comes from: https://github.com/torvalds/linux/blob/v6.18/arch/x86/include/asm/syscall_wrapper.h#L223

**Before fix**: Notice that `__se_sys` is incorrectly parsed as a type, `#name` incorrectly parsed as a preprocessor directive, while in fact they are semantically a single "pasted" identifier token, acting as a function name.
<img width="387" height="160" alt="image" src="https://github.com/user-attachments/assets/a30b9133-f00e-4f16-ad9e-c222da4c8678" />

**After fix**: token pasting is corretly parsed and highlighted.
<img width="367" height="154" alt="image" src="https://github.com/user-attachments/assets/f8d07f78-d7b0-4d79-9c61-085be21fb09b" />

Parser generation and tests all work corretly.
```txt
$ make TS=./tree-sitter-linux-x64-abi15
./tree-sitter-linux-x64-abi15 generate src/grammar.json
cc -Isrc -std=c11 -fPIC   -c -o src/parser.o src/parser.c
ar -rv libtree-sitter-c.a src/parser.o
r - src/parser.o
cc  -shared -Wl,-soname,libtree-sitter-c.so.15.0 src/parser.o  -o libtree-sitter-c.so

$ make TS=./tree-sitter-linux-x64-abi15 test
./tree-sitter-linux-x64-abi15 test
  ambiguities:
      1. ✓ pointer declarations vs expressions
      2. ✓ casts vs multiplications
      3. ✓ function-like type macros vs function calls
      4. ✓ function calls vs parenthesized declarators vs macro types
      5. ✓ Call expressions vs empty declarations w/ macros as types
      6. ✓ Comments after for loops with ambiguities
      7. ✓ Top-level macro invocations
  crlf:
      8. ✓ Line comments with escaped CRLF line endings
  declarations:
      9. ✓ Struct declarations
     10. ✓ Union declarations
     11. ✓ Enum declarations
     12. ✓ Struct declarations containing preprocessor directives
     13. ✓ Primitive-typed variable declarations
     14. ✓ Variable storage classes
     15. ✓ Composite-typed variable declarations
     16. ✓ Pointer variable declarations
     17. ✓ Typedefs
     18. ✓ Function declarations
     19. ✓ Function definitions
     20. ✓ Function specifiers after types
     21. ✓ Function definitions with macro attributes
     22. ✓ Linkage specifications
     23. ✓ Type qualifiers
     24. ✓ Local array declarations
     25. ✓ Attributes
     26. ✓ More Assembly
     27. ✓ Static in Array Declarations
  expressions:
     28. ✓ Number literals
     29. ✓ Identifiers
     30. ✓ Unicode Identifiers
     31. ✓ Common constants
     32. ✓ Function calls
     33. ✓ GNU inline assembly
     34. ✓ Function call with compound statement
     35. ✓ String literals
     36. ✓ Character literals
     37. ✓ Field access
     38. ✓ Boolean operators
     39. ✓ Math operators
     40. ✓ The comma operator
     41. ✓ Assignments
     42. ✓ Pointer operations
     43. ✓ Type-casts
     44. ✓ Sizeof expressions
     45. ✓ Alignof expressions
     46. ✓ Offsetof expressions
     47. ✓ Compound literals
     48. ✓ Compound literals with trailing commas
     49. ✓ Comments with escaped newlines
     50. ✓ Comments with escaped chars and newlines
     51. ✓ Generic Expressions
     52. ✓ Noreturn Type Qualifier
     53. ✓ Restrict Type Qualifier
     54. ✓ Ternary
     55. ✓ Concatenated strings
     56. ✓ Nonnull Type Qualifier
     57. ✓ Top Level Empty Expression Statement
     58. ✓ Sized Type Specifier With Type Qualifiers
  microsoft:
     59. ✓ declaration specs
     60. ✓ pointers
     61. ✓ call modifiers
     62. ✓ SEH exception handling
  preprocessor:
     63. ✓ Include directives
     64. ✓ Object-like macro definitions
     65. ✓ Function-like macro definitions
     66. ✓ Ifdefs
     67. ✓ Elifdefs
     68. ✓ Mixing #elif and #elifdef
     69. ✓ General if blocks
     70. ✓ Preprocessor conditionals in functions
     71. ✓ Preprocessor conditionals in struct/union bodies
     72. ✓ Unknown preprocessor directives
     73. ✓ Preprocessor expressions
  statements:
     74. ✓ If statements
     75. ✓ For loops
     76. ✓ While loops
     77. ✓ Labeled statements
     78. ✓ Switch statements
     79. ✓ Case statements separate from switch statements
     80. ✓ Return statements
     81. ✓ Comments with asterisks
     82. ✓ Comment with multiple backslashes
     83. ✓ Attributes
  types:
     84. ✓ Primitive types
     85. ✓ Type modifiers

Total parses: 85; successful parses: 85; failed parses: 0; success percentage: 100.00%; average speed: 3067 bytes/ms

syntax highlighting:
    ✓ names.c (20 assertions)
    ✓ keywords.c (3 assertions)

```