### PR TITLE
Add Test Option and Fix Test Target Name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(tree-sitter-c
         LANGUAGES C)
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+option(BUILD_TESTING "Build tests" ON)
 option(TREE_SITTER_REUSE_ALLOCATOR "Reuse the library allocator" OFF)
 
 set(TREE_SITTER_ABI_VERSION 14 CACHE STRING "Tree-sitter ABI version")
@@ -58,6 +59,8 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-c.pc"
 install(TARGETS tree-sitter-c
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
-add_custom_target(ts-test "${TREE_SITTER_CLI}" test
-                  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-                  COMMENT "tree-sitter test")
+if(BUILD_TESTING)
+    add_custom_target(ts-c-test "${TREE_SITTER_CLI}" test
+                      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                      COMMENT "tree-sitter test")
+endif()


### PR DESCRIPTION
Adds the standard [BUILD_TESTING](https://cmake.org/cmake/help/v4.2/variable/BUILD_TESTING.html#build-testing) option to give consumers of the project the ability to not build any tests.

Renames the 'ts-test' test target to 'ts-c-test' to avoid target name collisions with other TS projects that define their test target with the same name. In CMake, targets are defined in a global namespace, so if someone wants to add TS dependencies for various languages, the build fails due to duplicate target names.
