### PR TITLE
fix: missing operators for highlight

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -35,22 +35,50 @@
 "#include" @keyword
 (preproc_directive) @keyword
 
-"--" @operator
-"-" @operator
-"-=" @operator
-"->" @operator
 "=" @operator
-"!=" @operator
-"*" @operator
-"&" @operator
-"&&" @operator
-"+" @operator
-"++" @operator
 "+=" @operator
-"<" @operator
-"==" @operator
-">" @operator
+"-=" @operator
+"*=" @operator
+"/=" @operator
+"%=" @operator
+"&=" @operator
+"|=" @operator
+"^=" @operator
+"<<=" @operator
+">>=" @operator
+
+"++" @operator
+"--" @operator
+
+"+" @operator
+"-" @operator
+"*" @operator
+"/" @operator
+"%" @operator
+"~" @operator
+"&" @operator
+"|" @operator
+"^" @operator
+"<<" @operator
+">>" @operator
+
+"!" @operator
+"&&" @operator
 "||" @operator
+
+"==" @operator
+"!=" @operator
+"<" @operator
+">" @operator
+"<=" @operator
+">=" @operator
+
+"->" @operator
+
+"?" @operator
+":" @operator
+
+
 
 "." @delimiter
 ";" @delimiter


### PR DESCRIPTION
I based my work on list [Operators](https://en.cppreference.com/w/c/language/operators.html#Operators) to be as comprehensive as possible.