### PR TITLE
deps: bump tar-fs to 2.1.4 in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1462,9 +1462,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
-      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Updates the locked `tar-fs` from 2.1.2 to 2.1.4.

Evidence:
- `package-lock.json` resolved `tar-fs@2.1.2`
- `osv-scanner` reported GHSA-vj76-c3g6-qr5v and GHSA-8cj5-5rvv-wf4v at 2.1.2
- updated version: `2.1.4` (still satisfies `prebuildify`'s `^2.1.0` spec)

Validation:
- `osv-scanner` no longer reports tar-fs advisories after the update
- `npm install` resolves cleanly from the updated lock

Note: `npm test` cannot run locally without a native `tree-sitter` build present, and `npm ci` fails on the base branch too because the lock is out of sync with the registry for `node-addon-api`. This patch only touches the tar-fs lock entry.

Scope: dependency/lockfile update only.